### PR TITLE
fix: windows: fixed path normalize

### DIFF
--- a/autoload/file_protocol.vim
+++ b/autoload/file_protocol.vim
@@ -38,15 +38,18 @@ function! s:parse(bufname) abort
   return {'path': s:normpath(path)}
 endfunction
 
-if !has('win32') || (exists('+shellslash') && &shellslash)
+if !has('win32')
   " /home/john/README.md -> /home/john/README.md
   function! s:normpath(path) abort
     return a:path
   endfunction
 else
-  " /C/Users/John/README.md -> C:\Users\John\README.md
+  " /C/Users/John/README.md  -> C:\Users\John\README.md
+  " /C|/Users/John/README.md -> C:\Users\John\README.md
+  " /C:/Users/John/README.md -> C:\Users\John\README.md
+  " /C:\Users\John\README.md -> C:\Users\John\README.md
   function! s:normpath(path) abort
-    let path = substitute(a:path, '^/\([a-zA-Z]\)/', '\1:/')
-    return fnamemodify(path, 'gs?/?\\?')
+    let path = substitute(a:path, '^/\([a-zA-Z]\)[:|]\?[/\\]', '\1:/', '')
+    return fnamemodify(path, ':gs?/?\\?')
   endfunction
 endif


### PR DESCRIPTION
No need to check `shellslash'. Vim on Windows always works with backslashes (or slashes).

It supports variations output by various programs as the file protocol. See comments in the script.

Closes #1.