### PR TITLE
fix: supports URL encoding

### DIFF
--- a/autoload/file_protocol.vim
+++ b/autoload/file_protocol.vim
@@ -1,9 +1,12 @@
 function! file_protocol#edit() abort
   let expr = expand('<amatch>')
+  let buf = bufnr('%')
   let info = s:parse(expr)
   let opts = printf('++ff=%s ++enc=%s ++%s', &fileformat, &fileencoding, &binary ? 'bin' : 'nobin')
-  execute printf('keepalt keepjumps edit %s %s %s', opts, v:cmdarg, info.path)
-  execute printf('silent bwipeout! %s', fnameescape(expr))
+  execute printf('keepalt keepjumps edit %s %s %s', opts, v:cmdarg, fnameescape(info.path))
+  if bufname(buf) ==# expr
+    execute printf('silent bwipeout! %d', buf)
+  endif
   if has_key(info, 'column')
     execute printf('keepjumps normal! %dG%d|zv', info.line, info.column)
   elseif has_key(info, 'line')
@@ -15,7 +18,7 @@ function! file_protocol#read() abort
   let expr = expand('<amatch>')
   let info = s:parse(expr)
   let opts = printf('++ff=%s ++enc=%s ++%s', &fileformat, &fileencoding, &binary ? 'bin' : 'nobin')
-  execute printf('read %s %s %s', opts, v:cmdarg, info.path)
+  execute printf('read %s %s %s', opts, v:cmdarg, fnameescape(info.path))
 endfunction
 
 function! s:parse(bufname) abort
@@ -23,7 +26,7 @@ function! s:parse(bufname) abort
   let m1 = matchlist(path, '^\(.*\):\(\d\+\):\(\d\+\)$')
   if !empty(m1)
     return {
-          \ 'path': s:normpath(m1[1]),
+          \ 'path': s:normpath(s:decodeURI(m1[1])),
           \ 'line': m1[2] + 0,
           \ 'column': m1[3] + 0,
           \}
@@ -31,11 +34,17 @@ function! s:parse(bufname) abort
   let m2 = matchlist(path, '^\(.*\):\(\d\+\)$')
   if !empty(m2)
     return {
-          \ 'path': s:normpath(m2[1]),
+          \ 'path': s:normpath(s:decodeURI(m2[1])),
           \ 'line': m2[2] + 0,
           \}
   endif
-  return {'path': s:normpath(path)}
+  return {'path': s:normpath(s:decodeURI(path))}
+endfunction
+
+" /home/john%20doe/README.md -> /home/john doe/README.md
+function! s:decodeURI(uri) abort
+  return substitute(a:uri, '%\([0-9a-fA-F]\{2}\)',
+        \ { m -> nr2char(str2nr(m[1], 16)) }, 'g')
 endfunction
 
 if !has('win32') || (exists('+shellslash') && &shellslash)


### PR DESCRIPTION
- Decode URL encoding.
- Apply `fnameescape()` to path, because path may contain spaces.
- Execute `bwipeout` with bufnr instead path, because E94 error may occur with URL encoded path.
- Check bufname before execute `bwipeout`, just to be safe.